### PR TITLE
Bugfixes for no-igg mode and report sample labels

### DIFF
--- a/bin/lib/reports.py
+++ b/bin/lib/reports.py
@@ -70,7 +70,7 @@ class Reports:
             dt_frag_i = pd.read_csv(dt_frag_list[i], sep='\t', header=None, names=['Size','Occurrences'])
             frag_base_i = os.path.basename(dt_frag_list[i])
             sample_id = frag_base_i.split(".")[0]
-            sample_id_split = sample_id.split("_")
+            sample_id_split = sample_id.rsplit("_", 1)
             rep_i = sample_id_split[len(sample_id_split)-1]
             group_i ="_".join(sample_id_split[0:(len(sample_id_split)-1)])
 
@@ -133,7 +133,7 @@ class Reports:
             seacr_bed_i = pd.read_csv(seacr_bed_list[i], sep='\t', header=None, usecols=[0,1,2,3,4], names=['chrom','start','end','total_signal','max_signal'])
             bed_base_i = os.path.basename(seacr_bed_list[i])
             sample_id = bed_base_i.split(".")[0]
-            sample_id_split = sample_id.split("_")
+            sample_id_split = sample_id.rsplit("_", 1)
             rep_i = sample_id_split[len(sample_id_split)-1]
             group_i ="_".join(sample_id_split[0:(len(sample_id_split)-1)])
             seacr_bed_i['group'] = np.repeat(group_i, seacr_bed_i.shape[0])
@@ -215,7 +215,7 @@ class Reports:
             self.bam_df_list.append(bam_now)
             bam_base = os.path.basename(bam)
             sample_id = bam_base.split(".")[0]
-            [group_now,rep_now] = sample_id.split("_")
+            [group_now,rep_now] = sample_id.rsplit("_", 1)
             self.frip.at[k, 'group'] = group_now
             self.frip.at[k, 'replicate'] = rep_now
             self.frip.at[k, 'mapped_frags'] = bam_now.shape[0]

--- a/workflows/cutandrun.nf
+++ b/workflows/cutandrun.nf
@@ -536,7 +536,7 @@ workflow CUTANDRUN {
             */
             SEACR_NO_IGG (
                 ch_bedgraph_split.target,
-                ch_peak_threshold.collect()
+                ch_peak_threshold
             )
             ch_seacr_bed = SEACR_NO_IGG.out.bed
             ch_software_versions = ch_software_versions.mix(SEACR_NO_IGG.out.version.first().ifEmpty(null))


### PR DESCRIPTION
## 2 (very) small bugfixes:

1. In `SEACR_NO_IGG`: Remove `collect()` operator when passing threshold value parameter to SEACR 
2. In `reports.py`: Split off replicate IDs based on last underscore (in case users include other underscores in sample names)

With these I was able to get results when using `--igg_control false`