### PR TITLE
Fix small error popping up with newer releases of Nextflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -56,12 +56,13 @@ WorkflowMain.initialise(workflow, params, log)
 ========================================================================================
 */
 
+include { CUTANDRUN } from './workflows/cutandrun'
+
 workflow NFCORE_CUTANDRUN {
     /*
      * WORKFLOW: Run main nf-core/cutandrun analysis pipeline
      */
 
-    include { CUTANDRUN } from './workflows/cutandrun'
     CUTANDRUN ()
 
 }


### PR DESCRIPTION
This addresses issue #41 , which seems to be a new error popping up with Nextflow (the test was run using Nextflow 21.06.0-edge

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/cutandrun/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/cutandrun _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
