### PR TITLE
communicate yeast+fly as alternative spike-in genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mitochondrial reads can be filtered before peak calling by setting `--remove_mitochondrial_reads true`. `false` is default. If using a custom reference genome, user can specify the string that is used to denote the mitochondrial reads in the reference using `--mito_name` parameter.
 - The user can now specify explicitly if `end-to-end` vs `local` mode of Bowtie2 should be used by setting `--end_to_end` to `true` or `false`. `true` is default.
 - Added the name of the peak caller in the consensus peaks to make it clearer which peaks were used in the downstream reporting steps
+- Extended documentation for most common alternative spike-in genomes, i.e. yeast and fruit fly.
 
 ## [3.1] - 2023-02-20
 
@@ -36,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed deeptools correlation plots that were showing low levels of correlation even in test data by changing the plot to use Pearson correlation.
 - Corrected the SEACR p-value parameter description.
 - Fixed output of Picard mark/remove duplicate files so that the sorted, indexed bams for all files always output to the results folder.
-- Spikein genome processes and checks no longer run when the normalisation mode is set to something other than `SpikeIn`.
+- Spike-in genome processes and checks no longer run when the normalisation mode is set to something other than `SpikeIn`.
 - Pipeline will now fail gracefully when single-end reads are detected.
 
 ### Software dependencies

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,7 +87,7 @@ The easiest way to run the pipeline is by using one of the pre-configured genome
 
 - Spike-in genome Bowtie2 Index
 
-If the `genome` parameter is not supplied, the user must provide all the target genome data themselves (except the gene BED file). The default spike-in genome is e.coli given that this is the natural spike-in product of the protein production process. However, it is possible to spike-in different DNA during the experimental protocol and then set the `spikein_genome` to the target organism.
+If the `genome` parameter is not supplied, the user must provide all the target genome data themselves (except the gene BED file). The default spike-in genome is E. coli (identified by the string "K12-MG1655") given that this is the natural spike-in product of the protein production process. However, it is possible to spike-in different DNA during the experimental protocol and then set the `spikein_genome` to the target organism, i.e. for yeast (S. cerevisiae) set to "R64-1-1", for fruit fly (D. melanogaster) it is "BDGP6".
 
 ### Read Filtering and Duplication
 
@@ -107,9 +107,9 @@ If the assay has been modified to include a linear amplification step prior to P
 
 The default mode in the pipeline is to normalise stacked reads before peak calling for epitope abundance using spike-in normalisation.
 
-Traditionally, E. coli DNA is carried along with bacterially-produced enzymes that are used in CUT&RUN and CUT&Tag experiments and gets tagmented non-specifically during the reaction. The fraction of total reads that map to the E.coli genome depends on the yield of epitope-targeted CUT&Tag, and so depends on the number of cells used and the abundance of that epitope in chromatin. Since a constant amount of protein is added to the reactions and brings along a fixed amount of E. coli DNA, E. coli reads can be used to normalize epitope abundance in a set of experiments.
+Traditionally, DNA from E. coli is carried along with bacterially-produced enzymes that are used in CUT&RUN and CUT&Tag experiments and gets tagmented non-specifically during the reaction. The fraction of total reads that map to the E. coli genome depends on the yield of epitope-targeted CUT&Tag, and so depends on the number of cells used and the abundance of that epitope in chromatin. Since a constant amount of protein is added to the reactions and brings along a fixed amount of E. coli DNA, E. coli reads can be used to normalize epitope abundance in a set of experiments.
 
-Since the introduction of these techniques there are several factors that have reduced the usefulness of this type of normalisation in certain experimental conditions. Firstly, many commercially available kits now have very low levels of E.coli DNA in them, which therefore requires users to spike-in their own DNA for normalisation which is not always done. Secondly the normalisation approach is dependant on the cell count between samples being constant, which in our experience is quite difficult to achieve especially in tissue samples.
+Since the introduction of these techniques there are several factors that have reduced the usefulness of this type of normalisation in certain experimental conditions. Firstly, many commercially available kits now have very low levels of E. coli DNA in them, which therefore requires users to spike-in their own DNA for normalisation which is not always done. Secondly the normalisation approach is dependant on the cell count between samples being constant, which in our experience is quite difficult to achieve especially in tissue samples.
 
 For these reasons we provide several other modes of normalisation based on read count; however, it should be noted that this form of normalisation is more simplistic and does not take into account epitope abundance. These normalisation modes are performed by [Deeptools bamCoverage](https://deeptools.readthedocs.io/en/develop/content/tools/bamCoverage.html), some are more relevant than others to this type of data, we recommend using CPM with a bin size of 1 as a default.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ There are three keywords for controling program flow and results output:
 params {
     // References
     genome                     = null
-    spikein_genome             = "K12-MG1655"
+    spikein_genome             = "K12-MG1655" // a common E. coli strain, use "R64-1-1" for yeast (S. cerevisiae) spike-in, BDGP6 for the fruit fly (D. melanogaster)
     gene_bed                   = null
     blacklist                  = null
     save_reference             = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -92,7 +92,7 @@
                     "type": "string",
                     "default": "K12-MG1655",
                     "fa_icon": "fas fa-book",
-                    "description": "Name of the igenome reference for the spike-in genome"
+                    "description": "Name of the iGenome reference for the spike-in genome, defaulting to E. coli K12, for yeast set to R64-1-1, for fruit fly BDGP6"
                 },
                 "spikein_bowtie2": {
                     "type": "string",


### PR DESCRIPTION
Hello,

This is my very first contribution to nextflow and its many workflows - and it is a small one. It is just a little hurdle that I needed to overcome to help with an analysis with a "CUT&RUN Assay Kit" by Cell Signaling Technology that advises to spike with yeast DNA. I then found everything nicely prepared on your side but had to look into the source tree to find that information and then at the genomes definition to find the right identifiers - I anticipate this patch to help increasing the user base of your workflow - just a tiny bit that is.

I added respective comments/changes to the description in the .json files and usage.md. 

## PR checklist

- [ ] Make sure your code lints (`nf-core lint`).

Not done, admittedly, did not find lint on my conda installation.

- [ ] `CHANGELOG.md` is updated.

Done. I also fixed an omitted hyphen of a related earlier entry ("Spikein" -> "Spike-in", hope that is ok, can happily move that into another commit/PR).

- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Well, I should not add myself, and maybe not at all for those few comments.
