### PR TITLE
docs: Fix typo in README #Pipeline output

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ nextflow run nf-core/cutandrun \
 
 ## Pipeline output
 
-To see the the results of a test run with a full size dataset refer to the [results](https://nf-co.re/cutandrun/results) tab on the nf-core website pipeline page.
+To see the results of a test run with a full size dataset refer to the [results](https://nf-co.re/cutandrun/results) tab on the nf-core website pipeline page.
 For more details about the output files and reports, please refer to the
 [output documentation](https://nf-co.re/cutandrun/output).
 


### PR DESCRIPTION
This PR corrects a minor typographical error in the README file in the Pipeline Output section. No changes were made to code, configuration, or documentation beyond the README.

- "To see the the results of a test run..." should be "To see the results of a test run..."

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `README.md` is updated (including new tool citations and authors/contributors).
